### PR TITLE
Add `jsonrpc` and `grpc` service names

### DIFF
--- a/libraries/util/include/koinos/util/services.hpp
+++ b/libraries/util/include/koinos/util/services.hpp
@@ -13,6 +13,8 @@ namespace service {
    constexpr char p2p[]                 = "p2p";
    constexpr char contract_meta_store[] = "contract_meta_store";
    constexpr char account_history[]     = "account_history";
+   constexpr char grpc[]                = "grpc";
+   constexpr char jsonrpc[]             = "jsonrpc";
 }
 
 std::filesystem::path get_default_base_directory();


### PR DESCRIPTION
Resolves koinos/koinos-proto#204.

## Brief description
Add `jsonrpc` and `grpc` to our services definitions.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests
